### PR TITLE
Fixing Issue #9: To setup Product Details Screen Component

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@ import Footer from './components/Footer'
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Container } from 'react-bootstrap'
 import HomeScreen from './components/HomeScreen'
+import ProductScreen from './screens/ProductScreen'
 
 const App = () => {
   return (
@@ -12,6 +13,7 @@ const App = () => {
         <Container>
           <h1>Welcome to ProShop</h1>
           <Route path='/' component={HomeScreen} exact />
+          <Route path='/product/:id' component={ProductScreen} />
         </Container>
       </main>
       <Footer />

--- a/frontend/src/screens/ProductScreen.js
+++ b/frontend/src/screens/ProductScreen.js
@@ -1,9 +1,62 @@
+import { Link } from 'react-router-dom'
+import { Row, Col, Image, ListGroup, Card, Button } from 'react-bootstrap'
+import Rating from '../components/Rating'
+import products from '../products'
 
-const ProductScreen = () => {
+const ProductScreen = ({ match }) => {
+    const product = products.find(p => p._id === match.params.id)
     return (
-        <h3>
-            Product
-        </h3>
+        <>
+            <Link to='/' className='btn btn-light my-3'>Go Back</Link>
+            <Row>
+                <Col md={6}>
+                    <Image src={product.image} alt={product.name} fluid />
+                </Col>
+                <Col md={3}>
+                    <ListGroup variant='flush'>
+                        <ListGroup.Item>
+                            <h3>{product.name}</h3>
+                        </ListGroup.Item>
+                        <ListGroup.Item>
+                            <Rating value={product.rating} text={`${product.numReviews} reviews`} />
+                        </ListGroup.Item>
+                        <ListGroup.Item>
+                            Price: ${product.price}
+                        </ListGroup.Item>
+                        <ListGroup.Item>
+                            Description: {product.description}
+                        </ListGroup.Item>
+                    </ListGroup>
+                </Col>
+                <Col md={3}>
+                    <Card>
+                        <ListGroup varinat='flush'>
+                            <ListGroup.Item>
+                                <Row>
+                                    <Col>
+                                        Price:
+                                    </Col>
+                                    <Col><strong>${product.price}</strong>
+                                    </Col>
+                                </Row>
+                            </ListGroup.Item>
+                            <ListGroup.Item>
+                                <Row>
+                                    <Col>
+                                        Status:
+                                    </Col>
+                                    <Col>{product.countInStock > 0 ? 'In Stock' : 'Out of Stock'}
+                                    </Col>
+                                </Row>
+                            </ListGroup.Item>
+                            <ListGroup.Item>
+                                <Button className='btn-block' type='button' disabled={product.countInStock === 0}>Add to Cart</Button>
+                            </ListGroup.Item>
+                        </ListGroup>
+                    </Card>
+                </Col>
+            </Row>
+        </>
     )
 }
 

--- a/frontend/src/screens/ProductScreen.js
+++ b/frontend/src/screens/ProductScreen.js
@@ -1,0 +1,10 @@
+
+const ProductScreen = () => {
+    return (
+        <h3>
+            Product
+        </h3>
+    )
+}
+
+export default ProductScreen


### PR DESCRIPTION
This pull request includes two commits:
1. to create Product Screen, initial page with no product details. [commit 1](https://github.com/r00tshaim/ProShop/commit/995bb3a71252add4ab67b9ebf9657d3aab81eb2b) 
2. updating Product Screen to show more details about product [commit 2 ](https://github.com/r00tshaim/ProShop/commit/0f9909c046b6ecaba647f87133d557f462c49dde)

Changes Include:
-Adding Product Details Screen Component

Product Details Screen Component accepts following props:
match - this includes id which is passed with /product/:id endpoint

Product Details Screen Component currently displays following details:
Name
Image
Reviews
Price
Status (In Stock/Out of Stock)
Description

Dev Test:
Product details displayed, when we click a single product.

Screenshot:
![image](https://user-images.githubusercontent.com/31386526/119180037-58ecc880-ba8d-11eb-9732-743812e57ee6.png)

This Resolves:
Resolves #9 
