### PR TITLE
Fixing Issue #14: To Remove extra text from home screen

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,7 +11,6 @@ const App = () => {
       <Header />
       <main className='py-3'>
         <Container>
-          <h1>Welcome to ProShop</h1>
           <Route path='/' component={HomeScreen} exact />
           <Route path='/product/:id' component={ProductScreen} />
         </Container>


### PR DESCRIPTION
Changes Include:
Removing **Welcome to ProShop** text from home screen (App.js)

Dev Test:
**Welcome to ProShop** text  is not displayed now. 

Screenshot:
![image](https://user-images.githubusercontent.com/31386526/119219429-33020b00-bb03-11eb-8740-ca25654adddf.png)

This Resolves:
Resolves #14 
