### PR TITLE
Fixing Issue #19: To fetch products from backend to frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3125,6 +3125,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.0.tgz",
       "integrity": "sha512-1uIESzroqpaTzt9uX48HO+6gfnKu3RwvWdCcWSrX4csMInJfCo1yvKPNXCwXFRpJqRW25tiASb6No0YH57PXqg=="
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,11 +1,13 @@
 {
   "name": "frontend",
+  "proxy": "http://127.0.0.1:5000",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",
+    "axios": "^0.21.1",
     "react": "^17.0.2",
     "react-bootstrap": "^1.6.0",
     "react-dom": "^17.0.2",

--- a/frontend/src/screens/HomeScreen.js
+++ b/frontend/src/screens/HomeScreen.js
@@ -1,8 +1,38 @@
+import { useEffect, useState } from 'react'
 import { Row, Col } from "react-bootstrap"
-import products from "../products"
 import Product from '../components/Product'
+import axios from 'axios'
 
 const HomeScreen = () => {
+    //products - variable conatining all products to display
+    //setProducts - function to change products variable
+    const [products, setProducts] = useState([]);
+
+    //----------------- useEffect explanation -----------------
+    //similar to componentDidMount() and componentDidUpdate()
+    //componentDidMount() - is invoked immediately after a component is mounted (inserted into the tree).
+    //If you need to load data from a remote endpoint, this is a good place to instantiate the network request. Refer: https://reactjs.org/docs/react-component.html#componentdidmount
+    //componentDidUpdate() - is invoked immediately after updating occurs. This method is not called for the initial render.
+    //Use this as an opportunity to operate on the DOM when the component has been updated. Refer: https://reactjs.org/docs/react-component.html#componentdidupdate
+
+    //useEffect() hook accepts 2 arguments: ie. useEffect(callback[, dependencies]);
+    //dependencies:
+    //  - Not provided: the side-effect runs after every rendering.
+    //  - An empty array []: the side-effect runs once after the initial rendering.
+    //  - Has props or state values [prop1, prop2, ..., state1, state2]: the side-effect runs only when any depenendecy value changes. Refer: https://dmitripavlutin.com/react-useeffect-explanation/#2-the-dependencies-of-useeffect
+    //Does useEffect run after every render? Yes! By default, it runs both after the first render and after every update. Refer: https://reactjs.org/docs/hooks-effect.html#example-using-hooks
+    useEffect(() => {
+        const fetchProducts = async () => {
+            //const res = await axios.get('/api/products')
+            const { data } = await axios.get('/api/products')
+            //using setProducts function to change products variable
+            setProducts(data);
+        }
+
+        //to get all products
+        fetchProducts();
+    }, [])  //running useEffect at initial rendering of component
+
     return (
         <>
             <h1>Latest Products</h1>

--- a/frontend/src/screens/ProductScreen.js
+++ b/frontend/src/screens/ProductScreen.js
@@ -1,10 +1,24 @@
+import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { Row, Col, Image, ListGroup, Card, Button } from 'react-bootstrap'
 import Rating from '../components/Rating'
-import products from '../products'
+import axios from 'axios'
 
 const ProductScreen = ({ match }) => {
-    const product = products.find(p => p._id === match.params.id)
+    const [product, setProduct] = useState({})
+
+    //disable eslint rules for useEffect - as useEffect is using variable it throws warning. Refer: https://eslint.org/docs/2.13.1/user-guide/configuring#disabling-rules-with-inline-comments
+    /* eslint-disable */
+    useEffect(() => {
+        const fetchProduct = async () => {
+            const { data } = await axios.get(`/api/products/${match.params.id}`)
+            setProduct(data)
+        }
+
+        fetchProduct();
+    }, [])
+    /* eslint-enable */
+
     return (
         <>
             <Link to='/' className='btn btn-light my-3'>Go Back</Link>


### PR DESCRIPTION
Changes Include

- configuring frontend to fetch data from API endpoints
- adding proxy in frontend package.json to avoid crocs errors

Dev Testing:
HomeScreen renders all the products from backend
ProdcutScreen renders all info about product from backend

This Resolves:
Resolves #19 